### PR TITLE
Add group amount

### DIFF
--- a/src/bill.js
+++ b/src/bill.js
@@ -1,0 +1,73 @@
+const isEqualWith = require('lodash/isEqualWith')
+const isEqual = require('lodash/isEqual')
+const every = require('lodash/every')
+const omit = require('lodash/omit')
+
+const maybeToISO = date => date.toISOString ? date.toISOString() : date
+
+const looseDates = (val, otherVal, key) => {
+  // Loose equality for dates since when coming from Couch, they
+  // are ISO strings whereas just after scraping they are `Date`s.
+  if (val instanceof Date) {
+    return maybeToISO(val) == maybeToISO(otherVal)
+  }
+}
+
+/**
+ * Simple Model for Documents. Allows to specify
+ * `shouldSave`, `shouldUpdate` as methods.
+ *
+ * Has useful `isEqual` method
+ *
+ * Should eventually move to `cozy-konnector-libs`.
+ */
+class Document {
+  constructor (attrs) {
+    if (this.validate) {
+      this.validate(attrs)
+    }
+    Object.assign(this, attrs, {
+      metadata: {
+        version: attrs.metadata && attrs.metadata.version || this.constructor.version
+      }
+    })
+  }
+
+  toJSON () {
+    return this
+  }
+
+  /**
+   * Compares to another document deeply.
+   *
+   * `_id` and `_rev` are by default ignored in the comparison.
+   *
+   * By default, will compare dates loosely since you often
+   * compare existing documents (dates in ISO string) with documents
+   * that just have been scraped where dates are `Date`s.
+   */
+  isEqual (other, ignoreAttrs=['_id', '_rev'], strict=false) {
+    return !isEqualWith(
+      omit(this, ignoreAttrs),
+      omit(other, ignoreAttrs),
+      !strict && looseDates
+    )
+
+  }
+}
+
+class Bill extends Document {
+  shouldUpdate (existingEntry) {
+    return this.isEqual(existingEntry)
+  }
+
+  validate (attrs) {
+    if (!attrs) {
+      throw new Error("A bill should have an amount")
+    }
+  }
+}
+
+Bill.version = 1
+
+module.exports = Bill

--- a/src/bill.spec.js
+++ b/src/bill.spec.js
@@ -1,0 +1,37 @@
+const Bill = require('./Bill')
+const omit = require('lodash/omit')
+
+describe('bill', () => {
+  let billAttrs = {
+    type: 'health',
+    subtype: 'C GENERALISTE',
+    beneficiary: 'RAPHAEL',
+    isThirdPartyPayer: true,
+    date: '2017-08-21T22:00:00.000Z',
+    originalDate: '2017-08-17T22:00:00.000Z',
+    vendor: 'Ameli',
+    isRefund: true,
+    amount: 17.5,
+    originalAmount: 25,
+    fileurl: 'https://assure.ameli.fr/PortailAS/PDFServletDetailPaiementPT.dopdf?idPaiement=MTgwMDI1NzQ2MzE1MnxQfDIwMTcwODIyfDExNDA4NzgwOXwxMTQwODc4MDl8Q0VOVFJFIERFIFNBTlRFIERVIENIIEQnQSBVQkVOQVMgICAgICAgIHxUfFV8MTcuNXw=',
+    filename: '20170822_ameli.pdf',
+    groupAmount: 17.5,
+    metadata: { version: 1 },
+    invoice: 'io.cozy.files:c7a76b7eb6c60ccd0c8466047912132a',
+    _id: 'c7a76b7eb6c60ccd0c846604791940b1',
+    _rev: '3-dca38838252c09fbb6b024e34dcc8b30'
+  }
+  let bill = new Bill({...billAttrs, ...{
+    date: new Date(billAttrs.date),
+    originalDate: new Date(billAttrs.originalDate),
+  }})
+
+  it('should update if different', () => {
+    // No difference
+    expect(bill.shouldUpdate(billAttrs)).toBe(false)
+    // Attribute has changed
+    expect(bill.shouldUpdate({...billAttrs, ...{ metadata: { version: 7 }}})).toBe(true)
+    // Attribute has been deleted
+    expect(bill.shouldUpdate(omit(billAttrs, 'fileurl'))).toBe(true)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -208,10 +208,10 @@ function parseHealthCares ($, container, beneficiary, reimbursement) {
     const healthCare = {
       prestation: $(this).find('.naturePrestation').text().trim(),
       date,
-      montantPayé: parseAmount($(this).find('[id^=montantPaye]').text().trim()),
+      amountPaid: parseAmount($(this).find('[id^=montantPaye]').text().trim()),
       baseRemboursement: parseAmount($(this).find('[id^=baseRemboursement]').text().trim()),
       taux: $(this).find('[id^=taux]').text().trim(),
-      montantVersé: parseAmount($(this).find('[id^=montantVerse]').text().trim())
+      amountReimbursed: parseAmount($(this).find('[id^=montantVerse]').text().trim())
     }
 
     reimbursement.beneficiaries[beneficiary] = reimbursement.beneficiaries[beneficiary] || []
@@ -233,7 +233,7 @@ function parseParticipation ($, container, reimbursement) {
     reimbursement.participation = {
       prestation: $(this).find('[id^=naturePFF]').text().trim(),
       date,
-      montantVersé: parseAmount($(this).find('[id^=montantVerse]').text().trim())
+      amountReimbursed: parseAmount($(this).find('[id^=montantVerse]').text().trim())
     }
   })
 }
@@ -252,8 +252,8 @@ function getBills (reimbursements) {
           originalDate: healthCare.date.toDate(),
           vendor: 'Ameli',
           isRefund: true,
-          amount: healthCare.montantVersé,
-          originalAmount: healthCare.montantPayé,
+          amount: healthCare.amountReimbursed,
+          originalAmount: healthCare.amountPaid,
           fileurl: 'https://assure.ameli.fr' + reimbursement.link,
           filename: getFileName(reimbursement.date)
         })
@@ -269,7 +269,7 @@ function getBills (reimbursements) {
         originalDate: reimbursement.participation.date.toDate(),
         vendor: 'Ameli',
         isRefund: true,
-        amount: reimbursement.participation.montantVersé,
+        amount: reimbursement.participation.amountReimbursed,
         fileurl: 'https://assure.ameli.fr' + reimbursement.link,
         filename: getFileName(reimbursement.date)
       })

--- a/src/index.js
+++ b/src/index.js
@@ -87,8 +87,9 @@ const logIn = function (fields) {
     if ($('[title="Déconnexion du compte ameli"]').length !== 1) {
       log('debug', $('body').html(), 'No deconnection link found in the html')
       log('debug', 'Something unexpected went wrong after the login')
-      if ($('.centrepage h2')) {
-        log('error', $('.centrepage h2').text().trim())
+      const title = $('.centrepage h2')
+      if (title) {
+        log('error', title.text().trim())
         throw new Error('VENDOR_DOWN')
       }
       throw new Error('LOGIN_FAILED')

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,12 @@ module.exports = new BaseKonnector(function fetch (fields) {
 
 const checkLogin = function (fields) {
   log('info', 'Checking the length of the login')
+  if (!fields.login) {
+    throw new Error('No `login` field.')
+  }
+  if (!fields.password) {
+    throw new Error('No `password` field.')
+  }
   if (fields.login.length > 13) {
     // remove the key from the social security number
     fields.login = fields.login.substr(0, 13)


### PR DESCRIPTION
Adding `groupAmount` to the attributes of the `io.cozy.bills' will allow banking operations that cover multiple bills to correctly match.