### PR TITLE
🐝 fix: only use 1 search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,24 +138,7 @@ const fetchMainPage = function($) {
   // We can get the history only 6 months back
   const billUrl = urlService.getBillUrl(endDate, 6);
 
-  return request(billUrl).then($1 => {
-    log("info", "Fetching more bills");
-    return request(
-      "https://assure.ameli.fr/PortailAS/paiements.do?" +
-        "actionEvt=afficherPaiementsComplementaires&" +
-        "Beneficiaire=tout_selectionner&" +
-        "afficherReleves=true&" +
-        "afficherIJ=false&" +
-        "afficherPT=false&" +
-        "afficherInva=false&" +
-        "afficherRentes=false&" +
-        "afficherRS=false&" +
-        "indexPaiement=&"
-    ).then($2 => {
-      const full = $($1.html() + $2.html());
-      return full.find.bind(full);
-    });
-  });
+  return request(billUrl);
 };
 
 // Parse the fetched page to extract bill data.
@@ -231,7 +214,7 @@ const parseMainPage = function($) {
     });
   });
 
-  reimbursements = sortBy(reimbursements, "date");
+  reimbursements = sortBy(reimbursements, x => +x.date);
   return bluebird
     .map(
       reimbursements,

--- a/src/urlService.js
+++ b/src/urlService.js
@@ -27,15 +27,18 @@ class UrlService {
     return this.reimbursementUrl;
   }
 
-  /**
-   * @param endDate: a moment date
-   */
-  getBillUrl(endDate, monthsBack) {
-    const formatedEndDate = endDate.format("DD/MM/YYYY");
-    const startDate = endDate
-      .subtract(monthsBack, "months")
-      .format("DD/MM/YYYY");
-    return `${this.getBaseUrl()}Rechercher&DateDebut=${startDate}&DateFin=${formatedEndDate}&Beneficiaire=tout_selectionner&afficherReleves=false&afficherIJ=false&afficherPT=false&afficherInva=false&afficherRentes=false&afficherRS=false&indexPaiement=&idNotif=`;
+  getBillUrl() {
+    const action =
+      "afficherPaiementsComplementaires&" +
+      "Beneficiaire=tout_selectionner&" +
+      "afficherReleves=true&" +
+      "afficherIJ=false&" +
+      "afficherPT=false&" +
+      "afficherInva=false&" +
+      "afficherRentes=false&" +
+      "afficherRS=false&" +
+      "indexPaiement=&";
+    return `${this.getBaseUrl()}${action}`;
   }
 
   getDetailsUrl(idPaiement, naturePaiement, indexGroupe, indexPaiement) {


### PR DESCRIPTION
Since my change to fetch more bills, we would retrieve duplicated bills. Since
the first search was redundant with the second, this change makes the second
one the only one.

It has no startDate or endDate and works.