### PR TITLE
Ignore build branches in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ cache:
   yarn: true
   directories:
     - node_modules
+branches:
+  except:
+  - build
+  - latest
 script:
   - yarn build
   - yarn lint


### PR DESCRIPTION
Travis recently removed the "Build only if .travis.yml is present". We have to
patch .travis.yml to ignore build branches.