### PR TITLE
feat: Update baanks transactions regexp

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -101,6 +101,6 @@
       }
     }
   },
-  "banksTransactionRegExp": "(cpam|c\\.p\\.a\\.m|caisse primaire)",
+  "banksTransactionRegExp": "(cpc?am|c\\.p\\.(c\\.)?a\\.m|caisse primaire)",
   "manifest_version": "2"
 }


### PR DESCRIPTION
We were currently looking for "cpam", "c.p.a.m" or "caisse primaire".
But sometimes the transaction label contains "CPCAM". We have the case
for a user from Lyon. This PR adds an optional "c" on the regex, so we
also look for "cpcam" and "C.P.C.A.M"