### PR TITLE
[SCR-428] feat: Add qualification on 'attestation' file for mesPapiers app

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,10 @@ class AmeliConnector extends CookieKonnector {
             },
             fileAttributes: {
               metadata: {
-                carbonCopy: true
+                carbonCopy: true,
+                qualification: Qualification.getByLabel(
+                  'national_health_insurance_right_certificate'
+                )
               }
             }
           }


### PR DESCRIPTION
This PR adds a qualification for the "attestation" files from this connector. It was needed for a feature soon available in MesPapiers app