### PR TITLE
[SCR-526] feat: Add forgotten qualif in manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -127,7 +127,8 @@
     "SENTRY_V2"
   ],
   "qualification_labels": [
-    "health_invoice"
+    "health_invoice",
+    "national_health_insurance_right_certificate"
   ],
   "banksTransactionRegExp": "(cpc?am|c\\.p\\.(c\\.)?a\\.m|caisse primaire)",
   "manifest_version": "2"


### PR DESCRIPTION
Newly added qualif was not added to the qualification_labels list in the manifest. This PR fixes it