### PR TITLE
[SCR-683] feat: Remove insurance category from manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,7 +9,6 @@
   "editor": "Cozy",
   "vendor_link": "https://assure.ameli.fr/PortailAS/appmanager/PortailAS/assure",
   "categories": [
-    "insurance",
     "public_service"
   ],
   "fields": {


### PR DESCRIPTION
Removes "insurance" category in the manifest to display in just one category in the store