### PR TITLE
fix: Handle first connection page

### DIFF
--- a/src/SuperContentScript.js
+++ b/src/SuperContentScript.js
@@ -16,7 +16,7 @@ export default class SuperContentScript extends ContentScript {
   }
 
   async downloadFileInWorker(entry) {
-    const { form, ...requestOptions } = entry.requestOptions
+    const { form, ...requestOptions } = entry.requestOptions || {}
     if (form) {
       const body = new FormData()
       for (const [key, value] of Object.entries(form)) {

--- a/src/SuperContentScript.js
+++ b/src/SuperContentScript.js
@@ -135,7 +135,6 @@ class CssLocator {
   }
 
   async isPresent() {
-    await this.waitFor()
     const elements = this._getElements()
     return Boolean(elements.length)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,23 @@ const messagesUrl =
   '/PortailAS/appmanager/PortailAS/assure?_nfpb=true&_pageLabel=as_messages_recus_page'
 
 class AmeliContentScript extends SuperContentScript {
+  async gotoLoginForm() {
+    this.launcher.log('info', '🤖 gotoLoginForm starts')
+    await this.page.goto(baseUrl)
+    await this.page
+      .getByCss(
+        '.deconnexionButton, #connexioncompte_2nir_as, #id_r_cnx_btn_code'
+      )
+      .waitFor()
+    const firstConnectLocator = this.page.getByCss('#id_r_cnx_btn_code')
+    if (await firstConnectLocator.isPresent()) {
+      this.launcher.log('info', 'Found firstConnectLocator')
+      await firstConnectLocator.click()
+    }
+    await this.page
+      .getByCss('.deconnexionButton, #connexioncompte_2nir_as')
+      .waitFor()
+  }
   async ensureAuthenticated({ account }) {
     this.launcher.log('info', '🤖 ensureAuthenticated starts')
     this.bridge.addEventListener('workerEvent', this.onWorkerEvent.bind(this))
@@ -29,10 +46,7 @@ class AmeliContentScript extends SuperContentScript {
       await this.ensureNotAuthenticated()
       await this.waitForUserAuthentication()
     } else {
-      await this.page.goto(baseUrl)
-      await this.page
-        .getByCss('.deconnexionButton, #connexioncompte_2nir_as')
-        .waitFor()
+      await this.gotoLoginForm()
       const authenticated = await this.page.evaluate(checkAuthenticated)
       if (!authenticated) {
         await this.authWithCredentials(credentials)
@@ -110,10 +124,7 @@ class AmeliContentScript extends SuperContentScript {
 
   async ensureNotAuthenticated() {
     this.launcher.log('info', '🤖 ensureNotAuthenticated starts')
-    await this.page.goto(baseUrl)
-    await this.page
-      .getByCss('.deconnexionButton, #connexioncompte_2nir_as')
-      .waitFor()
+    await this.gotoLoginForm()
     const authenticated = await this.page.evaluate(checkAuthenticated)
     if (!authenticated) {
       return true


### PR DESCRIPTION
When we try to connect for the first time in a webview, an intermediate page is displayed.
Now the konnector is able to pass this page

+ fixes in SuperContentScript for special cases

- **fix: Do not wait for element in locator.isPresent**
- **fix: downloadFileInWorker handles empty requestOptions**
- **fix: Handle first connection page**
