### PR TITLE
feat: handle pub campain modal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,13 +82,26 @@ class AmeliContentScript extends SuperContentScript {
     if (document.readyState !== 'loading') {
       this.launcher.log('info', 'readyState')
       this.watchLoginForm.bind(this)()
+      this.watchCampagneElement.bind(this)()
     } else {
       window.addEventListener('DOMContentLoaded', () => {
         this.launcher.log('info', 'DOMLoaded')
         this.watchLoginForm.bind(this)()
+        this.watchCampagneElement.bind(this)()
       })
     }
   }
+  watchCampagneElement() {
+    this.launcher.log('info', '📍️ watchCampagneElement starts')
+    const modaleClosingButton = document.querySelector(
+      '#idBoutonFermerFenetreModale'
+    )
+    if (modaleClosingButton) {
+      this.launcher.log('info', 'Found openend campagne modal, closing it')
+      modaleClosingButton.click()
+    }
+  }
+
   watchLoginForm() {
     this.launcher.log('info', '📍️ watchLoginForm starts')
     const loginField = document.querySelector('#connexioncompte_2nir_as')
@@ -207,7 +220,7 @@ class AmeliContentScript extends SuperContentScript {
   async waitForUserAuthentication() {
     this.launcher.log('info', 'waitForUserAuthentication starts')
     await this.page.show()
-    await this.page.waitFor(checkAuthenticated.bind(this))
+    await this.page.waitFor(checkAuthenticated)
     await this.page.hide()
   }
 
@@ -457,7 +470,7 @@ connector
   })
 
 function checkAuthenticated() {
-  this.log('info', '📍️  checkAuthenticated starts')
+  console.log('info', '📍️  checkAuthenticated starts')
   return Boolean(document.querySelector('.deconnexionButton'))
 }
 


### PR DESCRIPTION
They sometimes add a specific advertising modal, now when it is detected its automatically closed.

It also remove the binding of "this" for the checkAuthenticated call in userLogin scenario. this was causing errore for obscure reasons, when its needed in other scenario. This will need to be discuss but it fixes the error for now